### PR TITLE
Normalize duplicate lookup and bump version to 1.6.3

### DIFF
--- a/awb-barcode-scanner2.0/assets/css/awb-scanner.css
+++ b/awb-barcode-scanner2.0/assets/css/awb-scanner.css
@@ -1,0 +1,63 @@
+/* AWB Scanner — CSS fixed centering (reticle kekal di tengah) */
+.awb-scanner{max-width:820px;margin:16px auto;padding:12px}
+
+/* Card */
+.awb-card{
+  background:#111;color:#e5e5e5;border-radius:16px;
+  padding:16px;box-shadow:0 10px 30px rgba(0,0,0,.35)
+}
+
+/* Video wrapper keeps aspect and provides anchor for overlay */
+.awb-video-wrap{
+  position:relative;width:100%;border-radius:12px;overflow:hidden;
+  background:#000;aspect-ratio:16/9
+}
+.awb-video-wrap video{
+  width:100%;height:100%;object-fit:cover;display:block
+}
+
+/* Overlay full cover */
+.awb-overlay{
+  position:absolute;
+  inset:0;
+  pointer-events:none;
+}
+
+/* Reticle sentiasa di tengah (guna absolute + transform) */
+.awb-reticle{
+  position:absolute;
+  top:50%;
+  left:50%;
+  transform:translate(-50%, -50%);
+  width:min(70%, 520px);
+  height:42%;
+  border:2px dashed rgba(255,255,255,.55);
+  border-radius:10px;
+  box-sizing:border-box;
+}
+
+/* Controls & inputs */
+.awb-controls{display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin-top:10px}
+.awb-select{flex:1;min-width:120px;padding:10px;border-radius:10px;border:1px solid #333;background:#1a1a1a;color:#eee}
+.awb-btn{padding:12px 14px;border-radius:10px;background:#2a2a2a;color:#fff;border:1px solid #333;cursor:pointer}
+.awb-btn:hover{filter:brightness(1.1)}
+.awb-btn-outline{background:transparent}
+.awb-btn-primary{background:#3a7afe}
+
+.awb-result,.awb-photo,.awb-post-fields{margin-top:12px;display:grid;gap:8px}
+.awb-result input,.awb-post-fields textarea{width:100%;padding:12px;border-radius:10px;border:1px solid #333;background:#1a1a1a;color:#eee}
+
+.awb-previews{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
+.awb-previews img{width:110px;height:110px;object-fit:cover;border-radius:8px;border:1px solid #333}
+
+.awb-actions{margin-top:14px;display:flex;gap:10px;align-items:center}
+.awb-status{font-size:.95rem}
+.awb-status.info{color:#c0c0c0}
+.awb-status.success{color:#86efac}
+.awb-status.error{color:#f87171}
+
+/* Mobile tweaks */
+@media (max-width:480px){
+  .awb-btn{flex:1}
+  .awb-controls{gap:6px}
+}

--- a/awb-barcode-scanner2.0/assets/js/awb-scanner.js
+++ b/awb-barcode-scanner2.0/assets/js/awb-scanner.js
@@ -1,0 +1,746 @@
+/**
+ * AWB Scanner JavaScript - Updated for stable cross-platform support
+ * Compatible with the new stable zxing.min.js
+ * Version: 1.6.1
+ */
+
+document.addEventListener('DOMContentLoaded', function() {
+    'use strict';
+
+    // Check if we're on a page with the scanner
+    const scannerRoot = document.getElementById('awb-scanner-root');
+    if (!scannerRoot) return;
+
+    class AWBScannerApp {
+        constructor() {
+            this.isScanning = false;
+            this.stream = null;
+            this.reader = null;
+            this.torch = null;
+            this.initializeElements();
+            this.setupEventListeners();
+            this.setupBeepAudio();
+            this.initializeReader();
+        }
+
+        initializeElements() {
+            this.video = document.getElementById('awb-video');
+            this.startBtn = document.getElementById('awb-start');
+            this.stopBtn = document.getElementById('awb-stop');
+            this.flashBtn = document.getElementById('awb-flash');
+            this.barcodeInput = document.getElementById('awb-barcode');
+            this.photosInput = document.getElementById('awb-photos');
+            this.previewsDiv = document.getElementById('awb-previews');
+            this.statusSelect = document.getElementById('awb-status-select');
+            this.contentInput = document.getElementById('awb-content-input');
+            this.submitBtn = document.getElementById('awb-submit');
+            this.statusDiv = document.getElementById('awb-status');
+            this.overlay = document.getElementById('awb-overlay');
+        }
+
+        setupEventListeners() {
+            this.startBtn.addEventListener('click', () => this.startScanning());
+            this.stopBtn.addEventListener('click', () => this.stopScanning());
+            this.flashBtn.addEventListener('click', () => this.toggleFlash());
+            this.photosInput.addEventListener('change', () => this.handlePhotoSelection());
+            this.submitBtn.addEventListener('click', () => this.submitForm());
+            this.barcodeInput.addEventListener('input', () => this.validateForm());
+            
+            // Handle page visibility changes
+            document.addEventListener('visibilitychange', () => {
+                if (document.hidden && this.isScanning) {
+                    this.stopScanning();
+                }
+            });
+        }
+
+        setupBeepAudio() {
+            this.beepEnabled = AWB_SCANNER_VARS.settings.beep;
+            this.beepVolume = AWB_SCANNER_VARS.settings.beep_volume;
+            
+            if (this.beepEnabled) {
+                this.audioContext = null;
+                try {
+                    this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
+                } catch (e) {
+                    console.warn('AudioContext not supported:', e);
+                }
+            }
+        }
+
+        playBeep() {
+            if (!this.beepEnabled || !this.audioContext) return;
+            
+            try {
+                const oscillator = this.audioContext.createOscillator();
+                const gainNode = this.audioContext.createGain();
+                
+                oscillator.connect(gainNode);
+                gainNode.connect(this.audioContext.destination);
+                
+                oscillator.frequency.setValueAtTime(800, this.audioContext.currentTime);
+                gainNode.gain.setValueAtTime(this.beepVolume, this.audioContext.currentTime);
+                gainNode.gain.exponentialRampToValueAtTime(0.001, this.audioContext.currentTime + 0.1);
+                
+                oscillator.start(this.audioContext.currentTime);
+                oscillator.stop(this.audioContext.currentTime + 0.1);
+            } catch (e) {
+                console.warn('Beep failed:', e);
+            }
+        }
+
+        async initializeReader() {
+            try {
+                // Load the ZXing library if not already loaded
+                if (typeof ZXing === 'undefined') {
+                    await this.loadZXingLibrary();
+                }
+
+                // Initialize the multi-format reader
+                this.reader = new ZXing.BrowserMultiFormatReader();
+                console.log('ZXing reader initialized successfully');
+                
+                this.updateStatus('Scanner ready - tap to start');
+                this.startBtn.disabled = false;
+            } catch (error) {
+                console.error('Failed to initialize ZXing reader:', error);
+                this.updateStatus('Scanner initialization failed: ' + error.message);
+                this.startBtn.disabled = true;
+            }
+        }
+
+        async loadZXingLibrary() {
+            return new Promise((resolve, reject) => {
+                if (typeof ZXing !== 'undefined') {
+                    resolve();
+                    return;
+                }
+
+                const script = document.createElement('script');
+                const pluginUrl = AWB_SCANNER_VARS.plugin_url || '';
+                script.src = pluginUrl + '/assets/vendor/zxing.min.js';
+                
+                script.onload = () => {
+                    console.log('ZXing library loaded successfully');
+                    resolve();
+                };
+                
+                script.onerror = () => {
+                    console.error('Failed to load ZXing library');
+                    reject(new Error('Failed to load ZXing library'));
+                };
+                
+                document.head.appendChild(script);
+            });
+        }
+
+        async startScanning() {
+            if (this.isScanning || !this.reader) return;
+
+            try {
+                this.updateStatus('Starting camera...');
+                
+                // Get camera constraints
+                const constraints = this.getCameraConstraints();
+                
+                // Show video container
+                this.video.style.display = 'block';
+                this.overlay.style.display = 'block';
+                
+                // Start scanning
+                this.stream = await this.reader.decodeFromVideoDevice(
+                    undefined, // Let the reader choose the best camera
+                    this.video,
+                    (result, error) => {
+                        if (result) {
+                            this.handleScanResult(result);
+                        } else if (error && !(error instanceof ZXing.NotFoundException)) {
+                            console.error('Scan error:', error);
+                        }
+                    }
+                );
+                
+                this.isScanning = true;
+                this.startBtn.disabled = true;
+                this.stopBtn.disabled = false;
+                this.updateStatus('Scanning... Point camera at barcode');
+                
+                // Try to enable torch if requested
+                this.initializeTorch();
+                
+            } catch (error) {
+                console.error('Failed to start scanning:', error);
+                this.updateStatus('Failed to start camera: ' + error.message);
+                this.handleScanError(error);
+            }
+        }
+
+        getCameraConstraints() {
+            const rearOnly = AWB_SCANNER_VARS.settings.rear_only;
+            const aspectRatio = AWB_SCANNER_VARS.settings.aspect_ratio || '16:9';
+            
+            let idealWidth = 1280;
+            let idealHeight = 720;
+            
+            // Adjust dimensions based on aspect ratio
+            switch (aspectRatio) {
+                case '4:3':
+                    idealWidth = 1024;
+                    idealHeight = 768;
+                    break;
+                case '1:1':
+                    idealWidth = 720;
+                    idealHeight = 720;
+                    break;
+            }
+            
+            const constraints = {
+                video: {
+                    width: { ideal: idealWidth, max: 1920 },
+                    height: { ideal: idealHeight, max: 1080 },
+                    frameRate: { ideal: 30, max: 60 }
+                }
+            };
+            
+            if (rearOnly) {
+                constraints.video.facingMode = { ideal: 'environment' };
+            }
+            
+            return constraints;
+        }
+
+        async initializeTorch() {
+            try {
+                if (this.stream && this.stream.getVideoTracks().length > 0) {
+                    const track = this.stream.getVideoTracks()[0];
+                    const capabilities = track.getCapabilities();
+                    
+                    if (capabilities.torch) {
+                        this.torch = track;
+                        this.flashBtn.style.display = 'block';
+                        console.log('Torch available');
+                    }
+                }
+            } catch (error) {
+                console.log('Torch not available:', error.message);
+            }
+        }
+
+        async toggleFlash() {
+            if (!this.torch) return;
+            
+            try {
+                const currentConstraints = this.torch.getConstraints();
+                const torchEnabled = currentConstraints.torch;
+                
+                await this.torch.applyConstraints({
+                    torch: !torchEnabled
+                });
+                
+                this.flashBtn.setAttribute('aria-pressed', (!torchEnabled).toString());
+                this.flashBtn.textContent = !torchEnabled ? 'Flash On' : 'Flash';
+                
+            } catch (error) {
+                console.error('Failed to toggle flash:', error);
+            }
+        }
+
+        handleScanResult(result) {
+            if (!result || !result.getText()) return;
+            
+            const barcodeText = result.getText().trim();
+            console.log('Barcode detected:', barcodeText);
+            
+            // Update UI
+            this.barcodeInput.value = barcodeText;
+            this.playBeep();
+            this.updateStatus(`Detected: ${barcodeText}`);
+            this.validateForm();
+            
+            // Add visual feedback
+            this.showScanSuccess();
+            
+            // Auto-stop scanning after successful detection
+            setTimeout(() => {
+                this.stopScanning();
+            }, 1000);
+        }
+
+        showScanSuccess() {
+            const overlay = this.overlay;
+            const reticle = overlay.querySelector('.awb-reticle');
+            
+            if (reticle) {
+                reticle.style.borderColor = '#00ff00';
+                reticle.style.boxShadow = '0 0 20px rgba(0, 255, 0, 0.8)';
+                
+                setTimeout(() => {
+                    reticle.style.borderColor = '';
+                    reticle.style.boxShadow = '';
+                }, 1500);
+            }
+        }
+
+        stopScanning() {
+            if (!this.isScanning) return;
+            
+            try {
+                if (this.reader) {
+                    this.reader.reset();
+                }
+                
+                if (this.stream) {
+                    this.stream.getTracks().forEach(track => track.stop());
+                    this.stream = null;
+                }
+                
+                this.video.style.display = 'none';
+                this.overlay.style.display = 'none';
+                this.flashBtn.style.display = 'none';
+                
+                this.isScanning = false;
+                this.torch = null;
+                this.startBtn.disabled = false;
+                this.stopBtn.disabled = true;
+                
+                this.updateStatus('Scanner stopped');
+                
+            } catch (error) {
+                console.error('Error stopping scanner:', error);
+            }
+        }
+
+        handleScanError(error) {
+            console.error('Scan error:', error);
+            
+            let message = 'Camera error';
+            if (error.name === 'NotAllowedError') {
+                message = 'Camera permission denied';
+            } else if (error.name === 'NotFoundError') {
+                message = 'No camera found';
+            } else if (error.name === 'NotReadableError') {
+                message = 'Camera is being used by another application';
+            }
+            
+            this.updateStatus(message);
+        }
+
+        handlePhotoSelection() {
+            const files = this.photosInput.files;
+            this.previewsDiv.innerHTML = '';
+            
+            if (files.length === 0) return;
+            
+            Array.from(files).forEach((file, index) => {
+                if (file.type.startsWith('image/')) {
+                    const reader = new FileReader();
+                    reader.onload = (e) => {
+                        const img = document.createElement('img');
+                        img.src = e.target.result;
+                        img.className = 'awb-preview-image';
+                        img.style.maxWidth = '100px';
+                        img.style.maxHeight = '100px';
+                        img.style.margin = '5px';
+                        img.style.borderRadius = '4px';
+                        this.previewsDiv.appendChild(img);
+                    };
+                    reader.readAsDataURL(file);
+                }
+            });
+            
+            this.validateForm();
+        }
+
+        validateForm() {
+            const hasBarcode = this.barcodeInput.value.trim().length > 0;
+            this.submitBtn.disabled = !hasBarcode;
+            
+            if (hasBarcode) {
+                this.submitBtn.classList.add('awb-btn-primary');
+                this.submitBtn.classList.remove('awb-btn-outline');
+            } else {
+                this.submitBtn.classList.remove('awb-btn-primary');
+                this.submitBtn.classList.add('awb-btn-outline');
+            }
+        }
+
+        async submitForm() {
+            const barcode = this.barcodeInput.value.trim();
+            if (!barcode) {
+                this.updateStatus('Please scan or enter a barcode first');
+                return;
+            }
+            
+            this.submitBtn.disabled = true;
+            this.updateStatus('Saving...');
+            
+            try {
+                const formData = new FormData();
+                formData.append('action', 'awb_create_post');
+                formData.append('barcode', barcode);
+                formData.append('content', this.contentInput.value.trim());
+                formData.append('post_status', this.statusSelect.value);
+                formData.append(AWB_SCANNER_VARS.nonce_name, AWB_SCANNER_VARS.nonce);
+                
+                // Add photos if selected
+                const files = this.photosInput.files;
+                if (files.length > 0) {
+                    Array.from(files).forEach((file, index) => {
+                        formData.append(`photos[${index}]`, file);
+                    });
+                }
+                
+                const response = await fetch(AWB_SCANNER_VARS.ajax_url, {
+                    method: 'POST',
+                    body: formData
+                });
+                
+                const result = await response.json();
+                
+                if (result.success) {
+                    this.updateStatus(result.data.message);
+                    this.resetForm();
+                    this.playBeep();
+                    
+                    // Show success message with link
+                    if (result.data.view_link) {
+                        this.showSuccessMessage(result.data.view_link);
+                    }
+                } else {
+                    this.updateStatus('Error: ' + (result.data?.message || 'Save failed'));
+                }
+                
+            } catch (error) {
+                console.error('Submit error:', error);
+                this.updateStatus('Network error: ' + error.message);
+            } finally {
+                this.submitBtn.disabled = false;
+            }
+        }
+
+        showSuccessMessage(viewLink) {
+            const message = document.createElement('div');
+            message.className = 'awb-success-message';
+            message.innerHTML = `
+                <div style="background: #d4edda; border: 1px solid #c3e6cb; color: #155724; padding: 15px; border-radius: 6px; margin: 15px 0;">
+                    <strong>✓ AWB saved successfully!</strong><br>
+                    <a href="${viewLink}" target="_blank" style="color: #155724; text-decoration: underline;">View Post</a>
+                </div>
+            `;
+            
+            this.statusDiv.appendChild(message);
+            
+            setTimeout(() => {
+                if (message.parentNode) {
+                    message.parentNode.removeChild(message);
+                }
+            }, 5000);
+        }
+
+        resetForm() {
+            this.barcodeInput.value = '';
+            this.contentInput.value = '';
+            this.photosInput.value = '';
+            this.previewsDiv.innerHTML = '';
+            this.validateForm();
+        }
+
+        updateStatus(message) {
+            this.statusDiv.textContent = message;
+            console.log('Status:', message);
+        }
+    }
+
+    // Initialize the scanner app
+    try {
+        new AWBScannerApp();
+        console.log('AWB Scanner initialized successfully');
+    } catch (error) {
+        console.error('Failed to initialize AWB Scanner:', error);
+    }
+});
+
+// Export for debugging
+if (typeof window !== 'undefined') {
+    window.AWBScannerApp = AWBScannerApp;
+}
+
+// --- AWB duplicate pre-check + beeps + banner ---
+function awbBeep(freq=800, dur=120, vol=0.2, reps=1, gap=120){
+  try{
+    const ctx = new (window.AudioContext||window.webkitAudioContext)();
+    let when = ctx.currentTime;
+    for(let i=0;i<reps;i++){
+      const o = ctx.createOscillator();
+      const g = ctx.createGain();
+      o.type = 'sine'; o.frequency.value = freq;
+      g.gain.value = vol;
+      o.connect(g); g.connect(ctx.destination);
+      o.start(when);
+      o.stop(when + dur/1000);
+      when += (dur+gap)/1000;
+    }
+  }catch(e){/* no audio */}
+}
+
+function awbBanner(msg, type='warn'){
+  let el = document.getElementById('awb-dup-banner');
+  if(!el){
+    el = document.createElement('div');
+    el.id='awb-dup-banner';
+    el.style.position='fixed';
+    el.style.left='50%'; el.style.top='20px';
+    el.style.transform='translateX(-50%)';
+    el.style.zIndex='99999';
+    el.style.padding='10px 14px';
+    el.style.borderRadius='10px';
+    el.style.background = type==='warn' ? '#ffefc6' : '#d1ffd6';
+    el.style.border='1px solid rgba(0,0,0,.1)';
+    el.style.boxShadow='0 8px 24px rgba(0,0,0,.18)';
+    el.style.fontFamily='system-ui, -apple-system, Segoe UI, Roboto, Poppins, Arial';
+    el.style.fontSize='14px';
+    document.body.appendChild(el);
+  }
+  el.textContent = msg;
+  el.style.display='block';
+  clearTimeout(el._t);
+  el._t = setTimeout(()=>{ el.style.display='none'; }, 1800);
+}
+
+async function awbCheckDuplicate(barcode){
+  try{
+    const fd = new FormData();
+    fd.set('action','awb_check_barcode');
+    fd.set('barcode', awbNormalize(barcode));
+    // optional: if you use custom post type, set it here
+    // fd.set('post_type','post');
+    const res = await fetch( (typeof awbAjax!=='undefined'? awbAjax.url : '/wp-admin/admin-ajax.php'), {
+      method:'POST', credentials:'same-origin', body: fd
+    });
+    const j = await res.json();
+    return j?.success && j?.data?.exists ? j.data : {exists:false};
+  }catch(e){ return {exists:false}; }
+}
+
+
+
+// Bind Save button(s) even if IDs differ
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('awb-form') || document.querySelector('form[data-awb-form]') || document.querySelector('form.awb-form');
+  function currentBarcode(){
+    const el = (form && form.querySelector('[name=barcode]')) || document.querySelector('[name=barcode]') || document.querySelector('#barcode');
+    return el ? (el.value||'').trim() : '';
+  }
+  const clickHandler = (e) => {
+    const t = e.target;
+    if (t.matches('#awb-save-btn, [data-awb-save], .awb-save-btn')){
+      e.preventDefault();
+      const bc = currentBarcode();
+      submitForm(bc);
+    }
+  };
+  document.addEventListener('click', clickHandler);
+
+  // If form submits normally, intercept and use AJAX
+  if (form){
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      submitForm(currentBarcode());
+    });
+  }
+});
+
+
+
+function awbNormalize(barcode){
+  return (barcode||'').toString().trim().toUpperCase().replace(/[^A-Z0-9]/g, '');
+}
+
+
+
+// --- AWB: TTS + vibration + fullscreen alert for duplicates ---
+function awbSpeak(text){
+  try{
+    if (!('speechSynthesis' in window)) return;
+    const u = new SpeechSynthesisUtterance(text);
+    u.rate = 1.0; u.pitch = 1.0;
+    window.speechSynthesis.cancel();
+    window.speechSynthesis.speak(u);
+  }catch(e){}
+}
+
+function awbVibrate(ms=180){ try{ if (navigator.vibrate) navigator.vibrate(ms); }catch(e){} }
+
+function awbFullAlert(msg){
+  let el = document.getElementById('awb-dup-full');
+  if(!el){
+    el = document.createElement('div');
+    el.id = 'awb-dup-full';
+    el.style.position='fixed';
+    el.style.inset='0';
+    el.style.display='grid';
+    el.style.placeItems='center';
+    el.style.background='rgba(220,0,0,0.18)';
+    el.style.backdropFilter='blur(2px)';
+    el.style.zIndex='999999';
+    const inner = document.createElement('div');
+    inner.style.padding='16px 22px';
+    inner.style.borderRadius='14px';
+    inner.style.background='#fff';
+    inner.style.boxShadow='0 10px 30px rgba(0,0,0,.25)';
+    inner.style.fontFamily='Inter, system-ui, -apple-system, Segoe UI, Roboto, Poppins, Arial';
+    inner.style.fontSize='22px';
+    inner.style.fontWeight='700';
+    inner.style.color='#b00020';
+    inner.style.textTransform='uppercase';
+    inner.id='awb-dup-full-inner';
+    el.appendChild(inner);
+    document.body.appendChild(el);
+  }
+  const inner = document.getElementById('awb-dup-full-inner');
+  inner.textContent = msg;
+  el.style.opacity='0'; el.style.display='grid';
+  // simple fade
+  el.animate([{opacity:0},{opacity:1}], {duration:120, fill:'forwards'});
+  clearTimeout(el._t);
+  el._t = setTimeout(()=>{
+    el.animate([{opacity:1},{opacity:0}], {duration:150, fill:'forwards'});
+    setTimeout(()=>{ el.style.display='none'; }, 160);
+  }, 1200);
+}
+
+
+
+// --- AWB: Instant duplicate alert immediately on scan (before Save) ---
+function awbBindInstantDupCheck(){
+  const input = document.querySelector('[name=barcode], #barcode');
+  if(!input) return;
+
+  let lastAnnounced = '';
+  async function onUpdate(raw){
+    const norm = awbNormalize(raw||'');
+    if(!norm || norm.length < 5) return;
+    if (AWBScannerGuards && AWBScannerGuards.seenRecently(norm)) return;
+    if (norm === lastAnnounced) return;
+
+    const dup = await awbCheckDuplicate(norm);
+    if (dup && dup.exists){ awbShowHardWarning('DUPLICATE BARCODE');
+      lastAnnounced = norm;
+      if (typeof awbBeep === 'function') awbBeep(1000,120,0.25,2,120);
+      if (typeof awbVibrate === 'function') awbVibrate(200);
+      if (typeof awbBanner === 'function') awbBanner('DUPLICATE BARCODE DETECTED', 'warn');
+      if (typeof awbFullAlert === 'function') awbFullAlert('DUPLICATE BARCODE DETECTED');
+      if (typeof awbSpeak === 'function') awbSpeak('Duplicate barcode detected');
+      if (AWBScannerGuards && AWBScannerGuards.remember) AWBScannerGuards.remember(norm);
+    }
+  }
+
+  // Input/change events
+  input.addEventListener('input', e => onUpdate(e.target.value));
+  input.addEventListener('change', e => onUpdate(e.target.value));
+
+  // Intercept programmatic .value set (ZXing often sets value directly)
+  try {
+    const desc = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+    if (desc && desc.configurable) {
+      Object.defineProperty(input, 'value', {
+        get(){ return desc.get.call(this); },
+        set(v){
+          desc.set.call(this, v);
+          onUpdate(v);
+        }
+      });
+    }
+  } catch(e){ /* ignore */ }
+
+  // First run if prefilled
+  if (input.value) onUpdate(input.value);
+}
+
+document.addEventListener('DOMContentLoaded', awbBindInstantDupCheck);
+
+
+
+// --- AWB: ZXing decode hook to block duplicates BEFORE app sees them ---
+(function(){
+  function hookZXing(){
+    try {
+      if (!window.ZXing || !ZXing.BrowserMultiFormatReader) return false;
+      const proto = ZXing.BrowserMultiFormatReader.prototype;
+      if (!proto || proto.__awb_hooked) return !!proto;
+      const orig = proto.decodeFromVideoDevice;
+      if (typeof orig !== 'function') return false;
+      proto.decodeFromVideoDevice = function(deviceId, videoElement, callback){
+        const wrapped = async (result, err, controls) => {
+          try{
+            if (result && result.text){
+              const norm = (typeof awbNormalize === 'function') ? awbNormalize(result.text) : (result.text||'').trim().toUpperCase().replace(/[^A-Z0-9]/g,'');
+              if (norm && norm.length >= 5){
+                const dup = await (typeof awbCheckDuplicate==='function' ? awbCheckDuplicate(norm) : Promise.resolve({exists:false}));
+                if (dup && dup.exists){ awbShowHardWarning('DUPLICATE BARCODE');
+                  // Immediate alert & DO NOT forward to app callback
+                  if (typeof awbBeep==='function') awbBeep(1000,120,0.25,2,120); awbShowHardWarning('DUPLICATE BARCODE');
+                  if (typeof awbVibrate==='function') awbVibrate(200);
+                  if (typeof awbBanner==='function') awbBanner('DUPLICATE BARCODE DETECTED', 'warn');
+                  if (typeof awbFullAlert==='function') awbFullAlert('DUPLICATE BARCODE DETECTED');
+                  if (typeof awbSpeak==='function') awbSpeak('Duplicate barcode detected');
+                  if (window.AWBScannerGuards && AWBScannerGuards.remember) AWBScannerGuards.remember(norm);
+                  return; // swallow duplicate
+                }
+              }
+            }
+          }catch(e){ /* ignore */ }
+          if (typeof callback === 'function') return callback(result, err, controls);
+        };
+        return orig.call(this, deviceId, videoElement, wrapped);
+      };
+      proto.__awb_hooked = true;
+      return true;
+    } catch(e){ return false; }
+  }
+  if (!hookZXing()){
+    // try again after libs load
+    document.addEventListener('DOMContentLoaded', hookZXing);
+    setTimeout(hookZXing, 1500);
+  }
+})();
+
+
+
+// --- AWB hard warning overlay (no dependencies) ---
+function awbShowHardWarning(msg){
+  try{
+    let el = document.getElementById('awb-hardwarn');
+    if(!el){
+      el = document.createElement('div');
+      el.id = 'awb-hardwarn';
+      el.style.position = 'fixed';
+      el.style.left = '50%';
+      el.style.top = '12%';
+      el.style.transform = 'translateX(-50%)';
+      el.style.zIndex = '2147483647';
+      el.style.background = '#B00020';
+      el.style.color = '#fff';
+      el.style.padding = '12px 18px';
+      el.style.borderRadius = '12px';
+      el.style.fontFamily = 'system-ui,-apple-system,Segoe UI,Roboto,Poppins,Arial';
+      el.style.fontSize = '18px';
+      el.style.fontWeight = '800';
+      el.style.letterSpacing = '0.5px';
+      el.style.boxShadow = '0 10px 30px rgba(0,0,0,.35)';
+      el.style.textTransform = 'uppercase';
+      el.style.pointerEvents = 'none';
+      el.style.opacity = '0';
+      document.body.appendChild(el);
+    }
+    el.textContent = msg || 'DUPLICATE BARCODE';
+    el.style.display = 'block';
+    el.animate([{opacity:0},{opacity:1}], {duration:120, fill:'forwards'});
+    clearTimeout(el._t);
+    el._t = setTimeout(()=>{
+      el.animate([{opacity:1},{opacity:0}], {duration:200, fill:'forwards'});
+      setTimeout(()=>{ el.style.display='none'; }, 220);
+    }, 1800);
+  }catch(e){}
+}
+

--- a/awb-barcode-scanner2.0/assets/vendor/zxing.min.js
+++ b/awb-barcode-scanner2.0/assets/vendor/zxing.min.js
@@ -1,0 +1,714 @@
+/*!
+ * ZXing Compatible Bundle v1.0.0 - STABLE CROSS-PLATFORM BARCODE DETECTION
+ * Works on iOS Safari, Android, Desktop - with QuaggaJS fallback
+ * For WordPress AWB Barcode Scanner Plugin
+ */
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+    typeof define === 'function' && define.amd ? define(['exports'], factory) :
+    (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.ZXing = {}));
+}(this, (function (exports) { 'use strict';
+
+    // Exception classes
+    class Exception extends Error {
+        constructor(message) {
+            super(message);
+            this.name = this.constructor.name;
+        }
+    }
+
+    class ArgumentException extends Exception {}
+    class ArithmeticException extends Exception {}
+    class ChecksumException extends Exception {}
+    class FormatException extends Exception {}
+    class IllegalArgumentException extends Exception {}
+    class IllegalStateException extends Exception {}
+    class NotFoundException extends Exception {}
+    class ReaderException extends Exception {}
+    class UnsupportedOperationException extends Exception {}
+    class WriterException extends Exception {}
+
+    // BarcodeFormat enum
+    const BarcodeFormat = {
+        AZTEC: 'AZTEC',
+        CODABAR: 'CODABAR',
+        CODE_39: 'CODE_39',
+        CODE_93: 'CODE_93',
+        CODE_128: 'CODE_128',
+        DATA_MATRIX: 'DATA_MATRIX',
+        EAN_8: 'EAN_8',
+        EAN_13: 'EAN_13',
+        ITF: 'ITF',
+        MAXICODE: 'MAXICODE',
+        PDF_417: 'PDF_417',
+        QR_CODE: 'QR_CODE',
+        RSS_14: 'RSS_14',
+        RSS_EXPANDED: 'RSS_EXPANDED',
+        UPC_A: 'UPC_A',
+        UPC_E: 'UPC_E',
+        UPC_EAN_EXTENSION: 'UPC_EAN_EXTENSION'
+    };
+
+    // Result classes
+    class Result {
+        constructor(text, rawBytes, resultPoints, format, timestamp) {
+            this.text = text;
+            this.rawBytes = rawBytes;
+            this.resultPoints = resultPoints || [];
+            this.format = format;
+            this.timestamp = timestamp || Date.now();
+        }
+
+        getText() { return this.text; }
+        getRawBytes() { return this.rawBytes; }
+        getResultPoints() { return this.resultPoints; }
+        getBarcodeFormat() { return this.format; }
+        getTimestamp() { return this.timestamp; }
+        toString() { return this.text; }
+    }
+
+    class ResultPoint {
+        constructor(x, y) {
+            this.x = x;
+            this.y = y;
+        }
+        getX() { return this.x; }
+        getY() { return this.y; }
+    }
+
+    // DecodeHintType enum
+    const DecodeHintType = {
+        OTHER: 'OTHER',
+        PURE_BARCODE: 'PURE_BARCODE',
+        POSSIBLE_FORMATS: 'POSSIBLE_FORMATS',
+        TRY_HARDER: 'TRY_HARDER',
+        CHARACTER_SET: 'CHARACTER_SET',
+        ALLOWED_LENGTHS: 'ALLOWED_LENGTHS',
+        ASSUME_CODE_39_CHECK_DIGIT: 'ASSUME_CODE_39_CHECK_DIGIT',
+        ASSUME_GS1: 'ASSUME_GS1',
+        RETURN_CODABAR_START_END: 'RETURN_CODABAR_START_END',
+        NEED_RESULT_POINT_CALLBACK: 'NEED_RESULT_POINT_CALLBACK',
+        ALLOWED_EAN_EXTENSIONS: 'ALLOWED_EAN_EXTENSIONS'
+    };
+
+    // QuaggaJS Integration - Lightweight barcode detection
+    class QuaggaJSIntegration {
+        constructor() {
+            this.isInitialized = false;
+            this.currentStream = null;
+            this.videoElement = null;
+        }
+
+        async initialize() {
+            if (this.isInitialized) return;
+            
+            // Check if QuaggaJS is available
+            if (typeof window !== 'undefined' && !window.Quagga) {
+                await this.loadQuaggaJS();
+            }
+            
+            this.isInitialized = true;
+        }
+
+        async loadQuaggaJS() {
+            return new Promise((resolve, reject) => {
+                if (window.Quagga) {
+                    resolve();
+                    return;
+                }
+
+                const script = document.createElement('script');
+                script.src = 'https://cdnjs.cloudflare.com/ajax/libs/quagga/0.12.1/quagga.min.js';
+                script.onload = () => resolve();
+                script.onerror = () => {
+                    // Fallback to basic pattern matching
+                    console.warn('QuaggaJS failed to load, using pattern matching fallback');
+                    resolve();
+                };
+                document.head.appendChild(script);
+            });
+        }
+
+        async detect(imageData) {
+            if (!window.Quagga) {
+                throw new NotFoundException('QuaggaJS not available');
+            }
+
+            return new Promise((resolve, reject) => {
+                const canvas = document.createElement('canvas');
+                canvas.width = imageData.width;
+                canvas.height = imageData.height;
+                const ctx = canvas.getContext('2d');
+                ctx.putImageData(imageData, 0, 0);
+
+                // Create temporary video element for Quagga
+                const tempVideo = document.createElement('video');
+                tempVideo.style.display = 'none';
+                document.body.appendChild(tempVideo);
+
+                window.Quagga.decodeSingle({
+                    src: canvas.toDataURL(),
+                    numOfWorkers: 0,
+                    inputStream: {
+                        size: Math.min(imageData.width, imageData.height)
+                    },
+                    decoder: {
+                        readers: [
+                            "code_128_reader",
+                            "ean_reader",
+                            "ean_8_reader", 
+                            "code_39_reader",
+                            "code_39_vin_reader",
+                            "codabar_reader",
+                            "upc_reader",
+                            "upc_e_reader"
+                        ]
+                    }
+                }, (result) => {
+                    document.body.removeChild(tempVideo);
+                    
+                    if (result && result.codeResult) {
+                        const format = this.mapQuaggaFormat(result.codeResult.format);
+                        const resultPoints = result.line ? [
+                            new ResultPoint(result.line.x1, result.line.y1),
+                            new ResultPoint(result.line.x2, result.line.y2)
+                        ] : [];
+                        
+                        resolve(new Result(
+                            result.codeResult.code,
+                            null,
+                            resultPoints,
+                            format,
+                            Date.now()
+                        ));
+                    } else {
+                        reject(new NotFoundException('No barcode found'));
+                    }
+                });
+            });
+        }
+
+        mapQuaggaFormat(quaggaFormat) {
+            const formatMap = {
+                'code_128': BarcodeFormat.CODE_128,
+                'ean': BarcodeFormat.EAN_13,
+                'ean_8': BarcodeFormat.EAN_8,
+                'code_39': BarcodeFormat.CODE_39,
+                'codabar': BarcodeFormat.CODABAR,
+                'upc': BarcodeFormat.UPC_A,
+                'upc_e': BarcodeFormat.UPC_E
+            };
+            return formatMap[quaggaFormat] || BarcodeFormat.CODE_128;
+        }
+    }
+
+    // Pattern-based fallback detector for basic barcodes
+    class PatternDetector {
+        detect(imageData) {
+            // Convert image to grayscale and analyze patterns
+            const grayData = this.toGrayscale(imageData);
+            const patterns = this.findPatterns(grayData, imageData.width, imageData.height);
+            
+            if (patterns.length === 0) {
+                throw new NotFoundException('No barcode patterns detected');
+            }
+
+            // Try to decode the most prominent pattern
+            const bestPattern = patterns[0];
+            const decoded = this.decodePattern(bestPattern);
+            
+            if (!decoded) {
+                throw new NotFoundException('Could not decode barcode pattern');
+            }
+
+            return new Result(
+                decoded.text,
+                null,
+                [new ResultPoint(bestPattern.x, bestPattern.y)],
+                decoded.format,
+                Date.now()
+            );
+        }
+
+        toGrayscale(imageData) {
+            const gray = new Uint8Array(imageData.width * imageData.height);
+            const data = imageData.data;
+            
+            for (let i = 0; i < data.length; i += 4) {
+                const luminance = 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2];
+                gray[i / 4] = luminance;
+            }
+            
+            return gray;
+        }
+
+        findPatterns(grayData, width, height) {
+            const patterns = [];
+            const threshold = 128;
+            
+            // Simple horizontal line detection
+            for (let y = 0; y < height; y++) {
+                let transitions = 0;
+                let lastPixel = grayData[y * width] > threshold;
+                
+                for (let x = 1; x < width; x++) {
+                    const currentPixel = grayData[y * width + x] > threshold;
+                    if (currentPixel !== lastPixel) {
+                        transitions++;
+                        lastPixel = currentPixel;
+                    }
+                }
+                
+                // If we have many transitions, it might be a barcode
+                if (transitions > 10 && transitions < 100) {
+                    patterns.push({
+                        x: width / 2,
+                        y: y,
+                        transitions: transitions,
+                        confidence: Math.min(transitions / 50, 1)
+                    });
+                }
+            }
+            
+            return patterns.sort((a, b) => b.confidence - a.confidence);
+        }
+
+        decodePattern(pattern) {
+            // This is a very basic pattern decoder
+            // In a real implementation, you would analyze the specific bar widths
+            
+            // Generate a plausible barcode based on pattern characteristics
+            const length = Math.floor(pattern.transitions / 3) + 8;
+            let code = '';
+            
+            // Generate numeric code based on pattern
+            for (let i = 0; i < length; i++) {
+                code += Math.floor((pattern.x + pattern.y + i * 7) % 10).toString();
+            }
+            
+            // Validate if it looks like a common barcode format
+            if (length >= 8 && length <= 14) {
+                return {
+                    text: code,
+                    format: length === 13 ? BarcodeFormat.EAN_13 : 
+                           length === 8 ? BarcodeFormat.EAN_8 : 
+                           BarcodeFormat.CODE_128
+                };
+            }
+            
+            return null;
+        }
+    }
+
+    // Main BrowserCodeReader class
+    class BrowserCodeReader {
+        constructor(reader, hints = null, options = {}) {
+            this.reader = reader;
+            this.hints = hints;
+            this.timeBetweenScansMillis = options.timeBetweenScansMillis || 500;
+            this.stream = null;
+            this.videoElement = null;
+            this.captureCanvas = null;
+            this.captureCanvasContext = null;
+            this.nativeBarcodeDetector = null;
+            this.quaggaIntegration = new QuaggaJSIntegration();
+            this.patternDetector = new PatternDetector();
+            
+            this.initNativeBarcodeDetector();
+        }
+
+        // Initialize native BarcodeDetector if available
+        initNativeBarcodeDetector() {
+            try {
+                if (typeof window !== 'undefined' && 'BarcodeDetector' in window) {
+                    this.nativeBarcodeDetector = new BarcodeDetector({
+                        formats: ['qr_code', 'code_128', 'code_39', 'code_93', 'codabar', 
+                                 'ean_8', 'ean_13', 'itf', 'upc_a', 'upc_e', 'data_matrix', 'pdf417']
+                    });
+                    console.log('Native BarcodeDetector initialized');
+                }
+            } catch (e) {
+                console.log('Native BarcodeDetector not available:', e.message);
+                this.nativeBarcodeDetector = null;
+            }
+        }
+
+        // Device enumeration
+        async listVideoInputDevices() {
+            if (!navigator.mediaDevices) {
+                throw new UnsupportedOperationException('navigator.mediaDevices is not supported');
+            }
+            
+            const devices = await navigator.mediaDevices.enumerateDevices();
+            return devices.filter(device => device.kind === 'videoinput');
+        }
+
+        async getVideoInputDevices() {
+            return this.listVideoInputDevices();
+        }
+
+        // Video stream management
+        async getUserMedia(constraints) {
+            if (!navigator.mediaDevices) {
+                throw new UnsupportedOperationException('navigator.mediaDevices is not supported');
+            }
+            return navigator.mediaDevices.getUserMedia(constraints);
+        }
+
+        // Prepare video element
+        prepareVideoElement(videoElementOrId) {
+            let videoElement;
+            
+            if (typeof videoElementOrId === 'string') {
+                videoElement = document.getElementById(videoElementOrId);
+            } else if (videoElementOrId instanceof HTMLVideoElement) {
+                videoElement = videoElementOrId;
+            } else {
+                throw new IllegalArgumentException('Video element not found or invalid');
+            }
+
+            if (!videoElement) {
+                throw new NotFoundException(`Video element with id "${videoElementOrId}" not found`);
+            }
+
+            videoElement.setAttribute('autoplay', 'true');
+            videoElement.setAttribute('muted', 'true');
+            videoElement.setAttribute('playsinline', 'true');
+
+            this.videoElement = videoElement;
+            return videoElement;
+        }
+
+        // Canvas setup for frame capture
+        createCaptureCanvas(videoElement = null) {
+            if (this.captureCanvas) {
+                return this.captureCanvas;
+            }
+
+            const canvas = document.createElement('canvas');
+            const video = videoElement || this.videoElement;
+            
+            if (video) {
+                canvas.width = video.videoWidth || 640;
+                canvas.height = video.videoHeight || 480;
+            }
+
+            this.captureCanvas = canvas;
+            this.captureCanvasContext = canvas.getContext('2d');
+            
+            return canvas;
+        }
+
+        // Capture frame from video
+        captureVideoFrame(video = null, canvas = null) {
+            const videoElement = video || this.videoElement;
+            const canvasElement = canvas || this.captureCanvas || this.createCaptureCanvas(videoElement);
+            const context = this.captureCanvasContext;
+
+            if (!videoElement) {
+                throw new IllegalStateException('Video element is not available');
+            }
+
+            if (videoElement.readyState !== videoElement.HAVE_ENOUGH_DATA) {
+                return null;
+            }
+
+            const videoWidth = videoElement.videoWidth || 640;
+            const videoHeight = videoElement.videoHeight || 480;
+
+            canvasElement.width = videoWidth;
+            canvasElement.height = videoHeight;
+            context.drawImage(videoElement, 0, 0, videoWidth, videoHeight);
+
+            return context.getImageData(0, 0, videoWidth, videoHeight);
+        }
+
+        // Multi-tier detection strategy
+        async decode(imageData, hints = null) {
+            return await this.decodeFromImageData(imageData, hints);
+        }
+
+        async decodeFromImageData(imageData, hints = null) {
+            let lastError = null;
+
+            // Tier 1: Try native BarcodeDetector (fastest, most accurate)
+            if (this.nativeBarcodeDetector) {
+                try {
+                    const result = await this.tryNativeDetection(imageData);
+                    if (result) {
+                        console.log('Detected with native BarcodeDetector:', result.getText());
+                        return result;
+                    }
+                } catch (error) {
+                    lastError = error;
+                    console.log('Native detection failed:', error.message);
+                }
+            }
+
+            // Tier 2: Try QuaggaJS (good cross-platform support)
+            try {
+                await this.quaggaIntegration.initialize();
+                const result = await this.quaggaIntegration.detect(imageData);
+                if (result) {
+                    console.log('Detected with QuaggaJS:', result.getText());
+                    return result;
+                }
+            } catch (error) {
+                lastError = error;
+                console.log('QuaggaJS detection failed:', error.message);
+            }
+
+            // Tier 3: Basic pattern detection fallback
+            try {
+                const result = this.patternDetector.detect(imageData);
+                if (result) {
+                    console.log('Detected with pattern matching:', result.getText());
+                    return result;
+                }
+            } catch (error) {
+                lastError = error;
+                console.log('Pattern detection failed:', error.message);
+            }
+
+            // All detection methods failed
+            throw new NotFoundException('No barcode detected with any method: ' + (lastError ? lastError.message : 'Unknown error'));
+        }
+
+        async tryNativeDetection(imageData) {
+            const canvas = document.createElement('canvas');
+            canvas.width = imageData.width;
+            canvas.height = imageData.height;
+            const ctx = canvas.getContext('2d');
+            ctx.putImageData(imageData, 0, 0);
+
+            const detectedCodes = await this.nativeBarcodeDetector.detect(canvas);
+            
+            if (detectedCodes && detectedCodes.length > 0) {
+                const code = detectedCodes[0];
+                
+                let format = BarcodeFormat.QR_CODE;
+                switch (code.format) {
+                    case 'qr_code': format = BarcodeFormat.QR_CODE; break;
+                    case 'code_128': format = BarcodeFormat.CODE_128; break;
+                    case 'code_39': format = BarcodeFormat.CODE_39; break;
+                    case 'code_93': format = BarcodeFormat.CODE_93; break;
+                    case 'codabar': format = BarcodeFormat.CODABAR; break;
+                    case 'ean_8': format = BarcodeFormat.EAN_8; break;
+                    case 'ean_13': format = BarcodeFormat.EAN_13; break;
+                    case 'itf': format = BarcodeFormat.ITF; break;
+                    case 'upc_a': format = BarcodeFormat.UPC_A; break;
+                    case 'upc_e': format = BarcodeFormat.UPC_E; break;
+                    case 'data_matrix': format = BarcodeFormat.DATA_MATRIX; break;
+                    case 'pdf417': format = BarcodeFormat.PDF_417; break;
+                }
+                
+                const resultPoints = code.cornerPoints ? 
+                    code.cornerPoints.map(p => new ResultPoint(p.x, p.y)) : [];
+                
+                return new Result(
+                    code.rawValue,
+                    null,
+                    resultPoints,
+                    format,
+                    Date.now()
+                );
+            }
+            
+            return null;
+        }
+
+        // Decode methods for video scanning
+        async decodeOnceFromVideoDevice(deviceId, videoElementOrId) {
+            const videoElement = this.prepareVideoElement(videoElementOrId);
+            
+            const constraints = {
+                video: {
+                    deviceId: deviceId ? { exact: deviceId } : undefined,
+                    facingMode: deviceId ? undefined : { ideal: 'environment' },
+                    width: { ideal: 1280, max: 1920 },
+                    height: { ideal: 720, max: 1080 }
+                }
+            };
+
+            this.stream = await this.getUserMedia(constraints);
+            videoElement.srcObject = this.stream;
+
+            return new Promise((resolve, reject) => {
+                const timeoutId = setTimeout(() => {
+                    this.reset();
+                    reject(new NotFoundException('No barcode found within timeout'));
+                }, 15000);
+
+                const tryDecode = async () => {
+                    try {
+                        const imageData = this.captureVideoFrame();
+                        if (imageData) {
+                            const result = await this.decode(imageData);
+                            if (result) {
+                                clearTimeout(timeoutId);
+                                resolve(result);
+                                return;
+                            }
+                        }
+                    } catch (error) {
+                        if (!(error instanceof NotFoundException)) {
+                            clearTimeout(timeoutId);
+                            reject(error);
+                            return;
+                        }
+                    }
+                    setTimeout(tryDecode, this.timeBetweenScansMillis);
+                };
+
+                const onVideoReady = () => {
+                    this.createCaptureCanvas(videoElement);
+                    setTimeout(tryDecode, this.timeBetweenScansMillis);
+                };
+
+                if (videoElement.readyState >= videoElement.HAVE_METADATA) {
+                    onVideoReady();
+                } else {
+                    videoElement.addEventListener('loadedmetadata', onVideoReady, { once: true });
+                }
+
+                videoElement.play().catch(reject);
+            });
+        }
+
+        async decodeFromVideoDevice(deviceId, videoElementOrId, callback) {
+            const videoElement = this.prepareVideoElement(videoElementOrId);
+            
+            const constraints = {
+                video: {
+                    deviceId: deviceId ? { exact: deviceId } : undefined,
+                    facingMode: deviceId ? undefined : { ideal: 'environment' },
+                    width: { ideal: 1280, max: 1920 },
+                    height: { ideal: 720, max: 1080 }
+                }
+            };
+
+            this.stream = await this.getUserMedia(constraints);
+            videoElement.srcObject = this.stream;
+
+            const continuousDecode = async () => {
+                if (!this.stream) return;
+                
+                try {
+                    const imageData = this.captureVideoFrame();
+                    if (imageData) {
+                        try {
+                            const result = await this.decode(imageData);
+                            if (result) {
+                                callback(result, null);
+                                return;
+                            }
+                        } catch (decodeError) {
+                            if (!(decodeError instanceof NotFoundException)) {
+                                callback(null, decodeError);
+                                return;
+                            }
+                        }
+                    }
+                } catch (error) {
+                    callback(null, error);
+                    return;
+                }
+                
+                setTimeout(continuousDecode, this.timeBetweenScansMillis);
+            };
+
+            const onVideoReady = () => {
+                this.createCaptureCanvas(videoElement);
+                setTimeout(continuousDecode, this.timeBetweenScansMillis);
+            };
+
+            if (videoElement.readyState >= videoElement.HAVE_METADATA) {
+                onVideoReady();
+            } else {
+                videoElement.addEventListener('loadedmetadata', onVideoReady, { once: true });
+            }
+
+            await videoElement.play();
+            return this.stream;
+        }
+
+        // Cleanup methods
+        reset() {
+            this.stopStreams();
+            if (this.videoElement) {
+                this.videoElement.srcObject = null;
+                this.videoElement = null;
+            }
+        }
+
+        stopStreams() {
+            if (this.stream) {
+                this.stream.getTracks().forEach(track => {
+                    track.stop();
+                });
+                this.stream = null;
+            }
+        }
+
+        stop() {
+            this.reset();
+        }
+    }
+
+    // Specific reader implementations
+    class BrowserQRCodeReader extends BrowserCodeReader {
+        constructor(hints, options = {}) {
+            super(null, hints, options);
+        }
+
+        async decodeFromImageData(imageData, hints = null) {
+            const result = await super.decodeFromImageData(imageData, hints);
+            // Filter for QR codes if we want to be strict
+            return result;
+        }
+    }
+
+    class BrowserMultiFormatReader extends BrowserCodeReader {
+        constructor(hints, options = {}) {
+            super(null, hints, options);
+            this.possibleFormats = hints && hints.get ? hints.get(DecodeHintType.POSSIBLE_FORMATS) : null;
+        }
+    }
+
+    // Export all classes and functions
+    exports.ArgumentException = ArgumentException;
+    exports.ArithmeticException = ArithmeticException;
+    exports.BarcodeFormat = BarcodeFormat;
+    exports.BrowserCodeReader = BrowserCodeReader;
+    exports.BrowserMultiFormatReader = BrowserMultiFormatReader;
+    exports.BrowserQRCodeReader = BrowserQRCodeReader;
+    exports.ChecksumException = ChecksumException;
+    exports.DecodeHintType = DecodeHintType;
+    exports.Exception = Exception;
+    exports.FormatException = FormatException;
+    exports.IllegalArgumentException = IllegalArgumentException;
+    exports.IllegalStateException = IllegalStateException;
+    exports.NotFoundException = NotFoundException;
+    exports.ReaderException = ReaderException;
+    exports.Result = Result;
+    exports.ResultPoint = ResultPoint;
+    exports.UnsupportedOperationException = UnsupportedOperationException;
+    exports.WriterException = WriterException;
+
+    // For global access (browser environment)
+    if (typeof window !== 'undefined') {
+        window.ZXing = exports;
+        window.BrowserMultiFormatReader = BrowserMultiFormatReader;
+        window.BrowserQRCodeReader = BrowserQRCodeReader;
+        window.BrowserCodeReader = BrowserCodeReader;
+        window.NotFoundException = NotFoundException;
+        window.BarcodeFormat = BarcodeFormat;
+        window.Result = Result;
+    }
+
+})));
+
+// Additional WordPress plugin compatibility
+if (typeof window !== 'undefined' && !window.ZXingBrowser) {
+    window.ZXingBrowser = window.ZXing;
+}

--- a/awb-barcode-scanner2.0/awb-barcode-scanner.php
+++ b/awb-barcode-scanner2.0/awb-barcode-scanner.php
@@ -1,0 +1,641 @@
+<?php
+/**
+ * Plugin Name: AWB Barcode Scanner (Offline Bundle)
+ * Description: Lite, fast barcode scanner with rear camera, beep, Publish/Draft, editable barcode, image size control, Breakdance meta, and offline decoder (local zxing.min.js). Admin sidebar + Admin Bar + Offline Decoder page (fetch/upload).
+ * Version: 1.6.3
+ * Author: Wan Mohd Aiman Binawebpro.com
+ * License: GPL2+
+ * Text Domain: awb-barcode-scanner
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+class AWB_Barcode_Scanner_Offline {
+    const VERSION = '1.6.3';
+    const NONCE_ACTION = 'awb_scanner_nonce_action';
+    const NONCE_NAME = 'awb_scanner_nonce';
+    const OPT_KEY = 'awb_scanner_settings';
+
+    public function __construct() {
+        add_action('init', [$this, 'register_shortcode']);
+        add_action('init', [$this, 'register_public_meta']);
+        add_action('admin_menu', [$this, 'admin_menu']);
+        add_action('admin_bar_menu', [$this, 'admin_bar_item'], 80);
+        add_action('wp_enqueue_scripts', [$this, 'register_assets']);
+        add_action('admin_enqueue_scripts', [$this, 'register_assets']);
+        add_action('wp_ajax_awb_create_post', [$this, 'handle_create_post']);
+        add_action('wp_ajax_nopriv_awb_create_post', [$this, 'handle_create_post']);
+        add_action('wp_ajax_awb_check_duplicate', [$this, 'handle_check_duplicate']);
+        add_action('wp_ajax_nopriv_awb_check_duplicate', [$this, 'handle_check_duplicate']);
+        add_action('admin_post_awb_fetch_zxing', [$this, 'handle_fetch_zxing']);
+        add_action('admin_post_awb_upload_zxing', [$this, 'handle_upload_zxing']);
+        $this->maybe_set_defaults();
+        $this->create_barcode_index();
+    }
+
+    private function maybe_set_defaults() {
+        $defaults = [
+            'button_scan' => 'SCAN NOW',
+            'button_save' => 'Save Now',
+            'default_status' => 'publish',
+            'rear_only' => 1,
+            'beep' => 1,
+            'beep_volume' => 0.7,
+            'aspect_ratio' => '16:9',
+            'max_width' => 200,
+            'max_height' => 200,
+        ];
+        $opt = get_option(self::OPT_KEY);
+        if (!$opt) update_option(self::OPT_KEY, $defaults);
+        else update_option(self::OPT_KEY, wp_parse_args($opt, $defaults));
+    }
+
+    private function create_barcode_index() {
+        global $wpdb;
+        
+        // Check if index already exists
+        $index_exists = $wpdb->get_var("
+            SHOW INDEX FROM {$wpdb->postmeta} 
+            WHERE Key_name = 'awb_barcode_idx'
+        ");
+        
+        if (!$index_exists) {
+            // Create index for faster barcode searches
+            $wpdb->query("
+                ALTER TABLE {$wpdb->postmeta} 
+                ADD INDEX awb_barcode_idx (meta_key, meta_value(20))
+            ");
+            
+            // Log the index creation
+            error_log('AWB Scanner: Created database index for barcode searches');
+        }
+    }
+
+    public function get_setting($key, $fallback = null) {
+        $opt = get_option(self::OPT_KEY, []);
+        return isset($opt[$key]) ? $opt[$key] : $fallback;
+    }
+
+    public function register_public_meta() {
+        register_post_meta('post', 'awb_barcode', ['type'=>'string','single'=>true,'show_in_rest'=>true,'auth_callback'=>'__return_true']);
+        register_post_meta('post', 'awb_photos', ['type'=>'string','single'=>true,'show_in_rest'=>true,'auth_callback'=>'__return_true']);
+    }
+
+    public function register_assets() {
+        $handle_js = 'awb-scanner-js';
+        $handle_css = 'awb-scanner-css';
+
+        wp_register_style($handle_css, plugins_url('assets/css/awb-scanner.css', __FILE__), [], self::VERSION);
+        wp_enqueue_style($handle_css);
+
+        wp_register_script($handle_js, plugins_url('assets/js/awb-scanner.js', __FILE__), [], self::VERSION, true);
+        $data = [
+            'ajax_url' => admin_url('admin-ajax.php'),
+            'nonce' => wp_create_nonce(self::NONCE_ACTION),
+            'nonce_name' => self::NONCE_NAME,
+            'is_ssl' => is_ssl(),
+            'plugin_url' => plugins_url('', __FILE__),
+            'settings' => [
+                'button_scan' => $this->get_setting('button_scan', 'SCAN NOW'),
+                'button_save' => $this->get_setting('button_save', 'Save Now'),
+                'rear_only'   => (int)$this->get_setting('rear_only', 1),
+                'beep'        => (int)$this->get_setting('beep', 1),
+                'beep_volume' => floatval($this->get_setting('beep_volume', 0.7)),
+                'aspect_ratio'=> $this->get_setting('aspect_ratio', '16:9'),
+                'default_status' => $this->get_setting('default_status', 'publish'),
+            ]
+        ];
+        wp_localize_script($handle_js, 'AWB_SCANNER_VARS', $data);
+        wp_enqueue_script($handle_js);
+    }
+
+    public function admin_menu() {
+        add_menu_page('AWB Scanner', 'AWB Scanner', 'manage_options', 'awb-scanner', [$this, 'render_settings_page'], 'dashicons-camera', 56);
+        add_submenu_page('awb-scanner', 'Settings', 'Settings', 'manage_options', 'awb-scanner', [$this, 'render_settings_page']);
+        add_submenu_page('awb-scanner', 'Offline Decoder', 'Offline Decoder', 'manage_options', 'awb-scanner-offline', [$this, 'render_offline_page']);
+    }
+
+    public function admin_bar_item($wp_admin_bar) {
+        if (!current_user_can('manage_options')) return;
+        $wp_admin_bar->add_node([
+            'id' => 'awb_scanner_top',
+            'title' => 'AWB Scanner',
+            'href' => admin_url('admin.php?page=awb-scanner'),
+        ]);
+    }
+
+    public function render_settings_page() {
+        if (isset($_POST['awb_save_settings']) && check_admin_referer('awb_save_settings_nonce')) {
+            $opt = [
+                'button_scan' => sanitize_text_field($_POST['button_scan'] ?? 'SCAN NOW'),
+                'button_save' => sanitize_text_field($_POST['button_save'] ?? 'Save Now'),
+                'default_status' => in_array($_POST['default_status'] ?? 'publish', ['publish','draft']) ? $_POST['default_status'] : 'publish',
+                'rear_only' => isset($_POST['rear_only']) ? 1 : 0,
+                'beep' => isset($_POST['beep']) ? 1 : 0,
+                'beep_volume' => min(max(floatval($_POST['beep_volume'] ?? 0.7),0),1),
+                'aspect_ratio' => in_array($_POST['aspect_ratio'] ?? '16:9', ['16:9','4:3','1:1']) ? $_POST['aspect_ratio'] : '16:9',
+                'max_width' => max(50, intval($_POST['max_width'] ?? 200)),
+                'max_height'=> max(50, intval($_POST['max_height'] ?? 200)),
+            ];
+            update_option(self::OPT_KEY, $opt);
+            echo '<div class="updated"><p>Saved.</p></div>';
+        }
+        $opt = get_option(self::OPT_KEY, []);
+        
+// --- AWB: helpers for barcode duplicate + perf ---
+if ( ! function_exists('awb_barcode_key') ) {
+function awb_barcode_key(){ return '_awb_barcode'; }
+}
+
+if ( ! function_exists('awb_find_post_by_barcode') ) {
+function awb_find_post_by_barcode( $barcode, $post_type = 'post' ){
+    $q = new WP_Query([
+        'post_type'      => $post_type,
+        'post_status'    => ['publish','draft','pending','private'],
+        'posts_per_page' => 1,
+        'no_found_rows'  => true,
+        'fields'         => 'ids',
+        'meta_query'     => [[
+            'key'   => awb_barcode_key(),
+            'value' => (string) $barcode,
+        ]],
+    ]);
+    return $q->have_posts() ? (int) $q->posts[0] : 0;
+}
+}
+
+if ( ! function_exists('awb_acquire_barcode_lock') ) {
+function awb_acquire_barcode_lock( $barcode ){
+    $key = 'awb_lock_' . md5( (string) $barcode );
+    if ( get_transient($key) ) return false;
+    set_transient($key, 1, 20); // 20s lock to avoid race duplicates
+    return $key;
+}
+}
+
+if ( ! function_exists('awb_release_barcode_lock') ) {
+function awb_release_barcode_lock( $lock_key ){
+    if ( $lock_key ) delete_transient( $lock_key );
+}
+}
+?>
+        <div class="wrap">
+            <h1>AWB Scanner Settings</h1>
+            <form method="post">
+                <?php wp_nonce_field('awb_save_settings_nonce'); ?>
+                <table class="form-table">
+                    <tr><th>Scan Button</th><td><input name="button_scan" value="<?php echo esc_attr($opt['button_scan'] ?? 'SCAN NOW'); ?>" class="regular-text"></td></tr>
+                    <tr><th>Save Button</th><td><input name="button_save" value="<?php echo esc_attr($opt['button_save'] ?? 'Save Now'); ?>" class="regular-text"></td></tr>
+                    <tr><th>Default Status</th><td>
+                        <select name="default_status">
+                            <option value="publish" <?php selected(($opt['default_status'] ?? 'publish')==='publish'); ?>>Publish</option>
+                            <option value="draft" <?php selected(($opt['default_status'] ?? 'publish')==='draft'); ?>>Draft</option>
+                        </select>
+                    </td></tr>
+                    <tr><th>Rear Camera Only</th><td><label><input type="checkbox" name="rear_only" <?php checked(!empty($opt['rear_only'])); ?>> Force back camera</label></td></tr>
+                    <tr><th>Beep</th><td><label><input type="checkbox" name="beep" <?php checked(!empty($opt['beep'])); ?>> Enable &nbsp; Volume <input type="number" step="0.05" min="0" max="1" name="beep_volume" value="<?php echo esc_attr($opt['beep_volume'] ?? 0.7); ?>" style="width:80px;"></label></td></tr>
+                    <tr><th>Aspect Ratio</th><td>
+                        <select name="aspect_ratio">
+                            <option>16:9</option>
+                            <option <?php selected(($opt['aspect_ratio'] ?? '16:9')==='4:3'); ?>>4:3</option>
+                            <option <?php selected(($opt['aspect_ratio'] ?? '16:9')==='1:1'); ?>>1:1</option>
+                        </select>
+                    </td></tr>
+                    <tr><th>Image Save Resolution</th><td>
+                        <input name="max_width" type="number" value="<?php echo esc_attr($opt['max_width'] ?? 200); ?>" style="width:90px;"> ×
+                        <input name="max_height" type="number" value="<?php echo esc_attr($opt['max_height'] ?? 200); ?>" style="width:90px;"> px
+                        <br><small>Smaller images = faster uploads. Recommended: 200x200px</small>
+                    </td></tr>
+                </table>
+                <p><button class="button button-primary" name="awb_save_settings" value="1">Save Settings</button></p>
+            </form>
+        </div>
+        <?php
+    }
+
+    public function render_offline_page() {
+        $file = plugins_url('assets/vendor/zxing.min.js', __FILE__);
+        $exists = file_exists(plugin_dir_path(__FILE__) . 'assets/vendor/zxing.min.js');
+        ?>
+        <div class="wrap">
+            <h1>Offline Decoder</h1>
+            <p>This plugin prefers the native <code>BarcodeDetector</code>. If your iPhone doesn't expose it, a local decoder (<code>zxing.min.js</code>) will be used to avoid CSP/CDN issues.</p>
+            <h2>Status: <?php echo $exists ? '<span style="color:green">Installed</span>' : '<span style="color:red">Not Found</span>'; ?></h2>
+            <?php if ($exists): ?>
+                <p>Local path: <code><?php echo esc_html($file); ?></code></p>
+            <?php endif; ?>
+            <h3>Upload a new decoder</h3>
+            <form method="post" enctype="multipart/form-data" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                <input type="hidden" name="action" value="awb_upload_zxing">
+                <?php wp_nonce_field('awb_upload_zxing'); ?>
+                <input type="file" name="zxing" accept=".js" required>
+                <button class="button button-primary">Upload</button>
+            </form>
+            <h3>Fetch from source (server-side)</h3>
+            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                <input type="hidden" name="action" value="awb_fetch_zxing">
+                <?php wp_nonce_field('awb_fetch_zxing'); ?>
+                <button class="button">Fetch ZXing From Source</button>
+            </form>
+            <p class="description">The file is saved to <code>/assets/vendor/zxing.min.js</code>.</p>
+        </div>
+        <?php
+    }
+
+    public function handle_upload_zxing() {
+        if (!current_user_can('manage_options') || !check_admin_referer('awb_upload_zxing')) wp_die('Not allowed');
+        if (empty($_FILES['zxing']['tmp_name'])) wp_die('No file.');
+        $dir = plugin_dir_path(__FILE__) . 'assets/vendor/';
+        if (!file_exists($dir)) wp_mkdir_p($dir);
+        $dest = $dir . 'zxing.min.js';
+        if (!move_uploaded_file($_FILES['zxing']['tmp_name'], $dest)) wp_die('Upload failed.');
+        wp_safe_redirect(admin_url('admin.php?page=awb-scanner-offline&uploaded=1'));
+        exit;
+    }
+
+    public function handle_fetch_zxing() {
+        if (!current_user_can('manage_options') || !check_admin_referer('awb_fetch_zxing')) wp_die('Not allowed');
+        $urls = [
+            'https://unpkg.com/@zxing/browser@0.1.5/umd/index.js',
+            'https://cdn.jsdelivr.net/npm/@zxing/browser@0.1.5/umd/index.js'
+        ];
+        $ok = false; $body = '';
+        foreach ($urls as $u) {
+            $resp = wp_remote_get($u, ['timeout' => 30]);
+            if (!is_wp_error($resp) && wp_remote_retrieve_response_code($resp) === 200) {
+                $body = wp_remote_retrieve_body($resp);
+                if ($body) { $ok = true; break; }
+            }
+        }
+        if (!$ok) wp_die('Fetch failed: server cannot reach sources.');
+        $dir = plugin_dir_path(__FILE__) . 'assets/vendor/';
+        if (!file_exists($dir)) wp_mkdir_p($dir);
+        file_put_contents($dir.'zxing.min.js', $body);
+        wp_safe_redirect(admin_url('admin.php?page=awb-scanner-offline&fetched=1'));
+        exit;
+    }
+
+    public function register_shortcode() { add_shortcode('awb_scanner', [$this, 'render_scanner']); }
+
+    public function render_scanner($atts = []) {
+        $opt = get_option(self::OPT_KEY, []);
+        $scan = esc_html($opt['button_scan'] ?? 'SCAN NOW');
+        $save = esc_html($opt['button_save'] ?? 'Save Now');
+        $default_status = esc_html($opt['default_status'] ?? 'publish');
+        ob_start(); ?>
+        <div id="awb-scanner-root" class="awb-scanner">
+            <div class="awb-card">
+                <div class="awb-video-wrap">
+                    <video id="awb-video" playsinline muted></video>
+                    <div id="awb-overlay" class="awb-overlay"><div class="awb-reticle"></div></div>
+                </div>
+                <div class="awb-controls">
+                    <button id="awb-start" class="awb-btn awb-btn-primary"><?php echo $scan; ?></button>
+                    <button id="awb-stop" class="awb-btn awb-btn-outline">Stop</button>
+                    <button id="awb-flash" class="awb-btn awb-btn-outline" aria-pressed="false">Flash</button>
+                </div>
+                <div class="awb-result">
+                    <label>Detected Barcode</label>
+                    <input id="awb-barcode" type="text" placeholder="— waiting —" />
+                </div>
+                <div class="awb-photo">
+                    <label>Attach Photo(s)</label>
+                    <input id="awb-photos" type="file" accept="image/*" capture="environment" multiple />
+                    <div id="awb-previews" class="awb-previews"></div>
+                </div>
+                <div class="awb-post-fields">
+                    <div class="awb-row">
+                        <label>Visibility</label>
+                        <select id="awb-status-select" class="awb-select">
+                            <option value="publish" <?php selected($default_status==='publish'); ?>>Publish</option>
+                            <option value="draft" <?php selected($default_status==='draft'); ?>>Draft</option>
+                        </select>
+                    </div>
+                    <label>Post Content (optional)</label>
+                    <textarea id="awb-content-input" rows="3" placeholder="Add any notes here..."></textarea>
+                </div>
+                <div class="awb-actions">
+                    <button id="awb-submit" class="awb-btn awb-btn-primary"><?php echo $save; ?></button>
+                    <div id="awb-status" class="awb-status"></div>
+                </div>
+            </div>
+        </div>
+        <?php return ob_get_clean();
+    }
+
+    private function resize_image_in_place($filepath, $max_w, $max_h) {
+        if (!file_exists($filepath)) return;
+        $editor = wp_get_image_editor($filepath);
+        if (is_wp_error($editor)) return;
+        $size = $editor->get_size();
+        if (empty($size['width']) || empty($size['height'])) return;
+        if ($size['width'] <= $max_w && $size['height'] <= $max_h) return;
+        
+        // Set JPEG quality to 80% for faster processing and smaller files
+        if (method_exists($editor, 'set_quality')) {
+            $editor->set_quality(80);
+        }
+        
+        $editor->resize($max_w, $max_h, false);
+        $editor->save($filepath);
+    }
+
+    private function insert_attachments_from_files($post_id, $files) {
+        require_once(ABSPATH . 'wp-admin/includes/file.php');
+        require_once(ABSPATH . 'wp-admin/includes/media.php');
+        require_once(ABSPATH . 'wp-admin/includes/image.php');
+
+        $max_w = intval($this->get_setting('max_width', 200));
+        $max_h = intval($this->get_setting('max_height', 200));
+
+        $attachment_ids = [];
+        if (isset($files['name']) && is_array($files['name'])) {
+            foreach ($files['name'] as $i => $name) {
+                if (empty($files['name'][$i])) continue;
+                $file_array = [
+                    'name' => sanitize_file_name($files['name'][$i]),
+                    'type' => $files['type'][$i] ?? '',
+                    'tmp_name' => $files['tmp_name'][$i] ?? '',
+                    'error' => $files['error'][$i] ?? 0,
+                    'size' => $files['size'][$i] ?? 0,
+                ];
+                $overrides = ['test_form' => false];
+                $movefile = wp_handle_sideload($file_array, $overrides);
+                if ($movefile && !isset($movefile['error'])) {
+                    $this->resize_image_in_place($movefile['file'], $max_w, $max_h);
+                    $filetype = wp_check_filetype($movefile['file']);
+                    $attachment = [
+                        'post_mime_type' => $filetype['type'],
+                        'post_title' => sanitize_file_name(pathinfo($movefile['file'], PATHINFO_FILENAME)),
+                        'post_content' => '',
+                        'post_status' => 'inherit',
+                    ];
+                    $attach_id = wp_insert_attachment($attachment, $movefile['file'], $post_id);
+                    $attach_data = wp_generate_attachment_metadata($attach_id, $movefile['file']);
+                    wp_update_attachment_metadata($attach_id, $attach_data);
+                    $attachment_ids[] = $attach_id;
+                }
+            }
+        }
+        if (!empty($attachment_ids)) {
+            set_post_thumbnail($post_id, $attachment_ids[0]);
+            update_post_meta($post_id, '_awb_photo_ids', $attachment_ids);
+            update_post_meta($post_id, 'awb_photos', implode(',', $attachment_ids));
+        }
+        return $attachment_ids;
+    }
+
+    public function handle_check_duplicate() {
+        $nonce = isset($_POST[self::NONCE_NAME]) ? sanitize_text_field($_POST[self::NONCE_NAME]) : '';
+        if (!wp_verify_nonce($nonce, self::NONCE_ACTION)) wp_send_json_error(['message'=>'Invalid security token.'],403);
+
+        $barcode_raw = isset($_POST['barcode']) ? wp_unslash($_POST['barcode']) : '';
+        $barcode_raw = is_string($barcode_raw) ? trim($barcode_raw) : '';
+        $barcode = sanitize_text_field($barcode_raw);
+        if (empty($barcode)) wp_send_json_error(['message'=>'No barcode provided.'],400);
+
+        $barcode_norm = function_exists('awb_normalize_barcode') ? awb_normalize_barcode($barcode_raw) : $barcode;
+
+        // Use shared lookup helpers so all meta variations are checked
+        $existing_post_id = 0;
+        if (function_exists('awb_find_post_by_barcode_any')) {
+            $existing_post_id = awb_find_post_by_barcode_any($barcode_raw);
+        } elseif (function_exists('awb_find_post_by_barcode_robust')) {
+            $existing_post_id = awb_find_post_by_barcode_robust($barcode_norm, 'post');
+        } elseif (function_exists('awb_find_post_by_barcode')) {
+            $existing_post_id = awb_find_post_by_barcode($barcode_norm, 'post');
+        }
+
+        if ($existing_post_id) {
+            wp_send_json_success([
+                'is_duplicate' => true,
+                'existing_post_id' => $existing_post_id,
+                'existing_link' => get_permalink($existing_post_id)
+            ]);
+        } else {
+            wp_send_json_success(['is_duplicate' => false]);
+        }
+    }
+
+    public function handle_create_post(){
+    /* AWB: relaxed auth for scanner roles */
+    $nonce = isset($_POST['nonce']) ? $_POST['nonce'] : (isset($_POST['_ajax_nonce']) ? $_POST['_ajax_nonce'] : '');
+    if ($nonce && function_exists('wp_verify_nonce') && !wp_verify_nonce($nonce, 'awb_scan')) {
+        wp_send_json_error(['message' => 'Invalid nonce'], 403);
+    }
+    if ( ! is_user_logged_in() || ! current_user_can('read') ) {
+        wp_send_json_error(['message' => 'Permission denied'], 403);
+    }
+
+    $barcode    = isset($_POST['barcode']) ? trim(wp_unslash($_POST['barcode'])) : '';
+    $barcode_raw = isset($_POST['barcode_raw']) ? trim(wp_unslash($_POST['barcode_raw'])) : $barcode;
+    $barcode_norm = function_exists('awb_normalize_barcode') ? awb_normalize_barcode($barcode) : $barcode;
+    $title      = isset($_POST['title']) ? sanitize_text_field(wp_unslash($_POST['title'])) : ('Parcel ' . $barcode);
+    $content    = isset($_POST['content']) ? wp_kses_post(wp_unslash($_POST['content'])) : '';
+    $post_type  = isset($_POST['post_type']) ? sanitize_key($_POST['post_type']) : 'post';
+
+    if ( $barcode === '' ) {
+        wp_send_json_error(['message' => 'Barcode missing'], 400);
+    }
+
+    // Server-side duplicate prevention
+    $existing_id = function_exists('awb_find_post_by_barcode_any') ? awb_find_post_by_barcode_any($barcode) : (function_exists('awb_find_post_by_barcode_robust') ? awb_find_post_by_barcode_robust($barcode, $post_type) : (function_exists('awb_find_post_by_barcode') ? awb_find_post_by_barcode($barcode, $post_type) : 0));
+    if ( $existing_id ) {
+        wp_send_json_success([
+            'message' => 'Duplicate prevented: already exists.',
+            'post_id' => $existing_id,
+            'edit'    => get_edit_post_link($existing_id, 'raw'),
+            'view'    => get_permalink($existing_id),
+            'duplicate' => true,
+        ]);
+    }
+
+    // Short lock to prevent race duplicates
+    $lock_key = awb_acquire_barcode_lock( $barcode );
+    if ( ! $lock_key ) {
+        wp_send_json_success([
+            'message' => 'Duplicate prevented (in progress by another operator).',
+            'duplicate' => true,
+        ]);
+    }
+
+    // Create post
+    $postarr = [
+        'post_title'   => $title,
+        'post_content' => $content,
+        'post_status'  => 'publish',
+        'post_type'    => $post_type,
+    ];
+
+    $post_id = wp_insert_post( $postarr, true );
+    if ( is_wp_error($post_id) ) {
+        awb_release_barcode_lock($lock_key);
+        wp_send_json_error(['message' => $post_id->get_error_message()], 500);
+    }
+
+    // Save the barcode meta
+    add_post_meta( $post_id, awb_barcode_key(), (string) $barcode_norm, true );
+    update_post_meta( $post_id, 'awb_barcode', (string) $barcode_norm );
+    update_post_meta( $post_id, 'awb_barcode_norm', (string) $barcode_norm );
+    update_post_meta( $post_id, 'awb_barcode_raw', (string) $barcode_raw );
+
+    // Faster media handling (disable sizes + lower quality + pre-scale)
+    if ( ! empty($_FILES['photos']) ) {
+        awb_insert_attachments_from_files( $post_id, $_FILES['photos'] );
+    }
+
+    awb_release_barcode_lock($lock_key);
+
+    wp_send_json_success([
+        'message' => 'Saved',
+        'post_id' => $post_id,
+        'edit'    => get_edit_post_link($post_id, 'raw'),
+        'view'    => get_permalink($post_id),
+        'duplicate' => false,
+    ]);
+}
+}
+new AWB_Barcode_Scanner_Offline();
+
+function awb_insert_attachments_from_files( $post_id, $files_field ){
+    require_once ABSPATH . 'wp-admin/includes/image.php';
+    require_once ABSPATH . 'wp-admin/includes/file.php';
+    require_once ABSPATH . 'wp-admin/includes/media.php';
+
+    // Disable generating intermediate sizes ONLY during these uploads
+    $sizes_cb = function( $sizes ){ return []; };
+    $quality_cb = function( $q ){ return 70; }; // good balance
+
+    add_filter('intermediate_image_sizes_advanced', $sizes_cb, 99);
+    add_filter('wp_editor_set_quality', $quality_cb, 99);
+
+    try {
+        $file_count = is_array($files_field['name']) ? count($files_field['name']) : 0;
+        for ( $i = 0; $i < $file_count; $i++ ) {
+            if ( ! isset($files_field['name'][$i]) || $files_field['error'][$i] !== UPLOAD_ERR_OK ) continue;
+
+            $single_file = [
+                'name'     => $files_field['name'][$i],
+                'type'     => $files_field['type'][$i],
+                'tmp_name' => $files_field['tmp_name'][$i],
+                'error'    => $files_field['error'][$i],
+                'size'     => $files_field['size'][$i],
+            ];
+
+            // Pre-scale huge camera images
+            $tmp = $single_file['tmp_name'];
+            $editor = wp_get_image_editor( $tmp );
+            if ( ! is_wp_error($editor) ) {
+                $editor->set_quality(70);
+                $size = $editor->get_size();
+                $max_w = 1600; $max_h = 1600;
+                if ( $size && ($size['width'] > $max_w || $size['height'] > $max_h) ) {
+                    $editor->resize( $max_w, $max_h, false );
+                }
+                $editor->save( $tmp ); // strips most EXIF, respects quality
+            }
+
+            // Sideload
+            $attachment_id = media_handle_sideload( $single_file, $post_id );
+            if ( is_wp_error($attachment_id) ) continue;
+
+            if ( ! has_post_thumbnail($post_id) ) {
+                set_post_thumbnail( $post_id, $attachment_id );
+            }
+        }
+    } finally {
+        remove_filter('intermediate_image_sizes_advanced', $sizes_cb, 99);
+        remove_filter('wp_editor_set_quality', $quality_cb, 99);
+    }
+}
+
+
+if ( ! function_exists('awb_find_post_by_barcode_robust') ) {
+function awb_find_post_by_barcode_robust( $barcode, $post_type = 'post' ){
+    $keys = array('_awb_barcode','awb_barcode','barcode','tracking_no','tracking_number');
+    foreach ($keys as $k){
+        $q = new WP_Query([
+            'post_type'      => $post_type,
+            'post_status'    => ['publish','draft','pending','private'],
+            'posts_per_page' => 1,
+            'no_found_rows'  => true,
+            'fields'         => 'ids',
+            'meta_query'     => [[ 'key' => $k, 'value' => (string)$barcode ]],
+        ]);
+        if ( $q->have_posts() ) return (int) $q->posts[0];
+    }
+    return 0;
+}
+}
+
+
+
+// AJAX: check if barcode exists (for pre-submit warning/beep)
+add_action('wp_ajax_awb_check_barcode','awb_ajax_check_barcode');
+add_action('wp_ajax_nopriv_awb_check_barcode','awb_ajax_check_barcode');
+if ( ! function_exists('awb_ajax_check_barcode') ) {
+function awb_ajax_check_barcode(){
+    $barcode    = isset($_POST['barcode']) ? trim(wp_unslash($_POST['barcode'])) : '';
+    $barcode_raw = isset($_POST['barcode_raw']) ? trim(wp_unslash($_POST['barcode_raw'])) : $barcode;
+    $barcode_norm = function_exists('awb_normalize_barcode') ? awb_normalize_barcode($barcode) : $barcode;
+    $post_type = isset($_POST['post_type']) ? sanitize_key($_POST['post_type']) : 'post';
+    if ($barcode === '') {
+        wp_send_json_error(['message'=>'Missing barcode'], 400);
+    }
+    $existing_id = function_exists('awb_find_post_by_barcode_any') ? awb_find_post_by_barcode_any($barcode) : (function_exists('awb_find_post_by_barcode_robust') ? awb_find_post_by_barcode_robust($barcode, $post_type) : (function_exists('awb_find_post_by_barcode') ? awb_find_post_by_barcode($barcode, $post_type) : 0));
+    if ($existing_id) {
+        wp_send_json_success(['exists'=>true,'post_id'=>$existing_id,'view'=>get_permalink($existing_id)]);
+    } else {
+        wp_send_json_success(['exists'=>false]);
+    }
+}
+}
+
+
+
+// Normalize barcode: trim, uppercase, strip non-alphanumerics
+if ( ! function_exists('awb_normalize_barcode') ) {
+function awb_normalize_barcode( $raw ){
+    $s = strtoupper( trim( (string) $raw ) );
+    $s = preg_replace('/[^A-Z0-9]/', '', $s);
+    return $s;
+}
+}
+
+
+
+if ( ! function_exists('awb_find_post_by_barcode_any') ) {
+function awb_find_post_by_barcode_any( $barcode_raw ){
+    $norm = awb_normalize_barcode($barcode_raw);
+    // 1) normalized meta key first
+    $q = new WP_Query([
+        'post_type'      => 'any',
+        'post_status'    => ['publish','draft','pending','private'],
+        'posts_per_page' => 1,
+        'no_found_rows'  => true,
+        'fields'         => 'ids',
+        'meta_query'     => [[ 'key' => 'awb_barcode_norm', 'value' => $norm ]],
+    ]);
+    if ( $q->have_posts() ) return (int) $q->posts[0];
+
+    // 2) legacy/meta keys exact (raw or normalized) across common keys
+    $keys = array('_awb_barcode','awb_barcode','barcode','tracking_no','tracking_number');
+    foreach ($keys as $k){
+        $q2 = new WP_Query([
+            'post_type'      => 'any',
+            'post_status'    => ['publish','draft','pending','private'],
+            'posts_per_page' => 1,
+            'no_found_rows'  => true,
+            'fields'         => 'ids',
+            'meta_query'     => [[
+                'key'   => $k,
+                'value' => array( (string)$barcode_raw, $norm ),
+                'compare' => 'IN',
+            ]],
+        ]);
+        if ( $q2->have_posts() ) return (int) $q2->posts[0];
+    }
+    return 0;
+}
+}
+

--- a/awb-barcode-scanner2.0/readme.txt
+++ b/awb-barcode-scanner2.0/readme.txt
@@ -1,0 +1,4 @@
+=== AWB Barcode Scanner (Offline Bundle) v1.6.3 ===
+Includes admin settings, rear camera, beep, publish/draft, editable barcode, image resize, Breakdance meta. 
+This build bundles your uploaded decoder file as /assets/vendor/zxing.min.js. 
+Note: your file is a simplified ZXing-like implementation; for best results replace it later via wp-admin → AWB Scanner → Offline Decoder with the official @zxing/browser UMD (index.js).


### PR DESCRIPTION
## Summary
- normalize submitted barcodes in the duplicate-check endpoint before lookup
- reuse the shared barcode lookup helpers so all meta key variants are respected
- bump the plugin bundle version metadata to 1.6.3 with the updated author attribution

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8e96bae1c8330b63d3cd60a3915f3