### PR TITLE
Prevent pattern detector from returning fabricated barcodes

### DIFF
--- a/awb-barcode-scanner2.0/assets/js/awb-scanner.js
+++ b/awb-barcode-scanner2.0/assets/js/awb-scanner.js
@@ -1,7 +1,7 @@
 /**
  * AWB Scanner JavaScript - Updated for stable cross-platform support
  * Compatible with the new stable zxing.min.js
- * Version: 1.6.1
+ * Version: 1.6.4
  */
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/awb-barcode-scanner2.0/assets/vendor/zxing.min.js
+++ b/awb-barcode-scanner2.0/assets/vendor/zxing.min.js
@@ -208,26 +208,40 @@
             // Convert image to grayscale and analyze patterns
             const grayData = this.toGrayscale(imageData);
             const patterns = this.findPatterns(grayData, imageData.width, imageData.height);
-            
+
             if (patterns.length === 0) {
                 throw new NotFoundException('No barcode patterns detected');
             }
 
-            // Try to decode the most prominent pattern
-            const bestPattern = patterns[0];
-            const decoded = this.decodePattern(bestPattern);
-            
-            if (!decoded) {
-                throw new NotFoundException('Could not decode barcode pattern');
+            let lastError = null;
+
+            for (const pattern of patterns) {
+                try {
+                    const decoded = this.decodePattern(pattern, grayData, imageData.width, imageData.height);
+
+                    if (decoded && decoded.text) {
+                        return new Result(
+                            decoded.text,
+                            decoded.rawBytes || null,
+                            [new ResultPoint(pattern.x, pattern.y)],
+                            decoded.format,
+                            Date.now()
+                        );
+                    }
+                } catch (error) {
+                    if (error instanceof NotFoundException || error instanceof FormatException) {
+                        lastError = error;
+                    } else {
+                        lastError = new NotFoundException(error && error.message ? error.message : 'Unknown pattern decoding error');
+                    }
+                }
             }
 
-            return new Result(
-                decoded.text,
-                null,
-                [new ResultPoint(bestPattern.x, bestPattern.y)],
-                decoded.format,
-                Date.now()
-            );
+            if (lastError) {
+                throw lastError;
+            }
+
+            throw new NotFoundException('Could not decode barcode pattern');
         }
 
         toGrayscale(imageData) {
@@ -273,30 +287,12 @@
             return patterns.sort((a, b) => b.confidence - a.confidence);
         }
 
-        decodePattern(pattern) {
-            // This is a very basic pattern decoder
-            // In a real implementation, you would analyze the specific bar widths
-            
-            // Generate a plausible barcode based on pattern characteristics
-            const length = Math.floor(pattern.transitions / 3) + 8;
-            let code = '';
-            
-            // Generate numeric code based on pattern
-            for (let i = 0; i < length; i++) {
-                code += Math.floor((pattern.x + pattern.y + i * 7) % 10).toString();
-            }
-            
-            // Validate if it looks like a common barcode format
-            if (length >= 8 && length <= 14) {
-                return {
-                    text: code,
-                    format: length === 13 ? BarcodeFormat.EAN_13 : 
-                           length === 8 ? BarcodeFormat.EAN_8 : 
-                           BarcodeFormat.CODE_128
-                };
-            }
-            
-            return null;
+        decodePattern() {
+            // The previous implementation attempted to fabricate plausible barcode
+            // values. That behaviour has been removed in favour of surfacing a
+            // proper failure so the calling flow can continue scanning with a real
+            // decoder.
+            throw new NotFoundException('Pattern decoding fallback is unavailable');
         }
     }
 

--- a/awb-barcode-scanner2.0/awb-barcode-scanner.php
+++ b/awb-barcode-scanner2.0/awb-barcode-scanner.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: AWB Barcode Scanner (Offline Bundle)
  * Description: Lite, fast barcode scanner with rear camera, beep, Publish/Draft, editable barcode, image size control, Breakdance meta, and offline decoder (local zxing.min.js). Admin sidebar + Admin Bar + Offline Decoder page (fetch/upload).
- * Version: 1.6.3
+ * Version: 1.6.4
  * Author: Wan Mohd Aiman Binawebpro.com
  * License: GPL2+
  * Text Domain: awb-barcode-scanner
@@ -11,7 +11,7 @@
 if ( ! defined( 'ABSPATH' ) ) exit;
 
 class AWB_Barcode_Scanner_Offline {
-    const VERSION = '1.6.3';
+    const VERSION = '1.6.4';
     const NONCE_ACTION = 'awb_scanner_nonce_action';
     const NONCE_NAME = 'awb_scanner_nonce';
     const OPT_KEY = 'awb_scanner_settings';

--- a/awb-barcode-scanner2.0/readme.txt
+++ b/awb-barcode-scanner2.0/readme.txt
@@ -1,4 +1,4 @@
-=== AWB Barcode Scanner (Offline Bundle) v1.6.3 ===
+=== AWB Barcode Scanner (Offline Bundle) v1.6.4 ===
 Includes admin settings, rear camera, beep, publish/draft, editable barcode, image resize, Breakdance meta. 
 This build bundles your uploaded decoder file as /assets/vendor/zxing.min.js. 
 Note: your file is a simplified ZXing-like implementation; for best results replace it later via wp-admin → AWB Scanner → Offline Decoder with the official @zxing/browser UMD (index.js).


### PR DESCRIPTION
## Summary
- stop the fallback PatternDetector from fabricating values and bubble decoding failures with NotFoundException
- iterate through detected patterns while preserving real decoder results only and provide clearer failure propagation
- bump the plugin bundle version metadata to 1.6.4 across PHP, JS and readme references

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d95ef260fc833096ec5b527f910574